### PR TITLE
Show error notification when .ovpn import fails (#30)

### DIFF
--- a/src/openvpn3_indicator/application.py
+++ b/src/openvpn3_indicator/application.py
@@ -781,7 +781,7 @@ class Application(Gtk.Application):
             self.invalid_sessions = True
         except: #TODO: Catch only expected exceptions
             logging.debug(traceback.format_exc())
-            logging.error(f'Failed to import configuration {name} from {path}')
+            self.error(f'Failed to import configuration {name} from {path}', notify=True)
 
     def action_config_import(self, _object):
         logging.info(f'Import Config')
@@ -833,4 +833,3 @@ class Application(Gtk.Application):
         logging.error(msg, *args, **kwargs)
         if notify:
             self.logging_notify(msg, icon='active-error')
-


### PR DESCRIPTION
## Context
Previously, when importing a `.ovpn` configuration file failed, the error was only logged in the terminal.  

## Changes
- Replaced `logging.error` with `self.error(..., notify=True)` in `on_config_import`.
- Added desktop notification to inform the user when the import fails.

## Result
Now, if a configuration import fails, the user will see a system notification like:

> Failed to import configuration MyVPN from /home/user/vpn/my_vpn.ovpn
<img width="554" height="117" alt="image" src="https://github.com/user-attachments/assets/feef59d1-2461-4c15-bd9a-2d43c432fd95" />

## Related issue
Closes #30